### PR TITLE
Add automated github action to update jellyfin-web

### DIFF
--- a/.github/workflows/update-jellyfin-web.yml
+++ b/.github/workflows/update-jellyfin-web.yml
@@ -1,0 +1,45 @@
+name: Update jellyfin-web Submodule
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Runs at 6am every day
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update jellyfin-web submodule
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get latest jellyfin-web release
+        id: latest
+        run: |
+          TAG=$(gh release view --repo jellyfin/jellyfin-web --json tagName -q .tagName)
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Update submodule to ${{ steps.latest.outputs.tag }}
+        run: |
+          git submodule update --init jellyfin-web
+          cd jellyfin-web
+          git fetch --depth=1 origin ${{ steps.latest.outputs.tag }}
+          git checkout FETCH_HEAD
+          cd ..
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "Update jellyfin-web submodule to ${{ steps.latest.outputs.tag }}"
+          title: "Update jellyfin-web submodule to ${{ steps.latest.outputs.tag }}"
+          body: |
+            Automated update of the `jellyfin-web` submodule to [`${{ steps.latest.outputs.tag }}`](https://github.com/jellyfin/jellyfin-web/releases/tag/${{ steps.latest.outputs.tag }}).
+          branch: update/jellyfin-web-${{ steps.latest.outputs.tag }}
+          delete-branch: true
+          labels: dependencies

--- a/.github/workflows/update-jellyfin-web.yml
+++ b/.github/workflows/update-jellyfin-web.yml
@@ -1,23 +1,26 @@
-name: Update jellyfin-web Submodule
+name: Update jellyfin-web 🌍
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # Runs at 6am every day
+    - cron: "0 4 * * *"
   workflow_dispatch:
 
 jobs:
-  update:
+  main:
     name: Update jellyfin-web submodule
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Check out Git repository 🔎
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Get latest jellyfin-web release
+      - name: Find latest jellyfin-web release 🏷️
         id: latest
         run: |
           TAG=$(gh release view --repo jellyfin/jellyfin-web --json tagName -q .tagName)
@@ -25,21 +28,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Update submodule to ${{ steps.latest.outputs.tag }}
+      - name: Update submodule to ${{ steps.latest.outputs.tag }} 🆙
         run: |
           git submodule update --init jellyfin-web
           cd jellyfin-web
-          git fetch --depth=1 origin ${{ steps.latest.outputs.tag }}
+          git fetch --depth=1 origin tag ${{ steps.latest.outputs.tag }}
           git checkout FETCH_HEAD
           cd ..
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+      - name: Create pull request 🏗️
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
+          token: ${{ secrets.JF_BOT_TOKEN }}
           commit-message: "Update jellyfin-web submodule to ${{ steps.latest.outputs.tag }}"
-          title: "Update jellyfin-web submodule to ${{ steps.latest.outputs.tag }}"
-          body: |
-            Automated update of the `jellyfin-web` submodule to [`${{ steps.latest.outputs.tag }}`](https://github.com/jellyfin/jellyfin-web/releases/tag/${{ steps.latest.outputs.tag }}).
-          branch: update/jellyfin-web-${{ steps.latest.outputs.tag }}
+          committer: "jellyfin-bot <team@jellyfin.org>"
+          author: "jellyfin-bot <team@jellyfin.org>"
+          title: "Update jellyfin-web to ${{ steps.latest.outputs.tag }}"
+          body: "Update jellyfin-web to [`${{ steps.latest.outputs.tag }}`](https://github.com/jellyfin/jellyfin-web/releases/tag/${{ steps.latest.outputs.tag }})"
+          branch: "ci/jellyfin-web-${{ steps.latest.outputs.tag }}"
           delete-branch: true
           labels: dependencies


### PR DESCRIPTION
@nielsvanvelzen You mentioned in https://github.com/jellyfin-labs/jellyfin-titanos/pull/64#issuecomment-4231949830 that you wanted to automate it so i figured why not just do it 😉 

The action runs at 6:00 every day and updates the submodule to the latest release. There is also a workflow_dispatch for when you manually want to run it.