### PR TITLE
Fix spawn npm ENOENT on Windows when using nvm

### DIFF
--- a/scripts/_utils.ts
+++ b/scripts/_utils.ts
@@ -19,7 +19,7 @@ export async function exec(cmd: string, ...params: string[]): Promise<void> {
 
 	try {
 		await new Promise<void>((resolve, reject) => {
-			const childProcess = spawn(cmd, params, { stdio: 'inherit' });
+			const childProcess = spawn(cmd, params, { stdio: 'inherit', shell: true });
 
 			childProcess.on('error', (err) => reject(err));
 


### PR DESCRIPTION
On Windows, npm is a batch file (npm.cmd) rather than a native executable. Node's child_process.spawn does not search for .cmd extensions by default, so bare spawn('npm', ...) calls fail with ENOENT on Windows — including when Node is managed by nvm-windows.

Adding `shell: true` to the spawn options routes the command through the OS shell (cmd.exe on Windows, /bin/sh on Unix), which resolves .cmd and shell aliases correctly.

Why this is safe:
- The commands being spawned (npm ci, npm run build:production) are hardcoded in the calling scripts — there is no user-supplied input, so there is no shell injection risk.
- On Linux/macOS the behavior is unchanged: npm was already resolvable as a plain binary, and shell: true simply delegates to /bin/sh with the same result.
- This is the [recommended approach](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows) in the Node.js documentation for running .bat/.cmd files on Windows.